### PR TITLE
Remove mongo session managment

### DIFF
--- a/pilot_apps/camunda/pom-docker.xml
+++ b/pilot_apps/camunda/pom-docker.xml
@@ -125,7 +125,7 @@
 			<artifactId>spring-session-jdbc</artifactId>
 		</dependency>
 
-		<!-- MongoDB Session Cache -->
+	<!-- MongoDB Session Cache 
 		<dependency>
 			<groupId>org.springframework.session</groupId>
 			<artifactId>spring-session-data-mongodb</artifactId>
@@ -134,6 +134,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 		</dependency>
+	-->
 
 		<!-- Keycloak Identity Prover Plugin  -->
 		<dependency>

--- a/pilot_apps/camunda/src/main/resources/application.yaml
+++ b/pilot_apps/camunda/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ formbuilder.pipeline.service.username: ${FORMBUILDER_PIPELINE_USERNAME}
 formbuilder.pipeline.service.password: ${FORMBUILDER_PIPELINE_PASSWORD}
 formbuilder.pipeline.service.bpm-url: ${FORMBUILDER_PIPELINE_BPM_URL}
 
-spring.data.mongodb.uri: ${MONGODB_URI:mongodb://localhost}
+#spring.data.mongodb.uri: ${MONGODB_URI:mongodb://localhost}
 
 spring.datasource:
   jdbc-url: ${JDBC_URL:jdbc:h2:./camunda-db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}


### PR DESCRIPTION
Moving back to Postgresql Session management to reduce components to maintain and resolve HA issues with Mongodb