### PR TITLE
Fixing random deformed icons

### DIFF
--- a/apps/forms-flow-ai/forms-flow-web/src/styles.scss
+++ b/apps/forms-flow-ai/forms-flow-web/src/styles.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 $white: #fff;
 $grey: #6c757d;
 $gray-100: #f8f9fa;
@@ -32,9 +34,9 @@ $danger: $red;
 $light: $gray-100;
 $dark: $gray-800;
 
-@import "~bootstrap/scss/bootstrap.scss";
-@import "~font-awesome/scss/font-awesome";
-@import "~formiojs/dist/formio.full.min.css";
+@import url(https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css);
+@import url(https://cdn.jsdelivr.net/npm/formiojs@4.13.1/dist/formio.full.min.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css);
 
 .container,
 .container-sm,


### PR DESCRIPTION
**Root cause:**
The fontawesome.scss imported in styles.scss gets compiled by sass. Using external CSS imports from CDN prevents this inconsistency from compilation as sass does not compile css files.

The cause of this problem appears to be the double quotes used to define the variables inside fontawesome.css ([Refer](https://github.com/FortAwesome/Font-Awesome/issues/10842#issuecomment-309448198))

**Chrome - Before this change**
![Content renders as question mark](https://user-images.githubusercontent.com/84348052/124670913-86d57300-de69-11eb-9c43-79287b5e0af4.png)
Whenever this happens, it is unpredictable how the icon will ultimately render although it correctly renders 99/100 times.


**Chrome - After this change**
![Content renders as the correct UTF value](https://user-images.githubusercontent.com/84348052/124671132-e6cc1980-de69-11eb-93b3-969882fd3ac5.png)

**Firefox - Before**
![Firefox Before](https://user-images.githubusercontent.com/84348052/124672101-54c51080-de6b-11eb-8572-fe382c931d8d.png)

**Firefox - After**
![Firefox after](https://user-images.githubusercontent.com/84348052/124672152-6ad2d100-de6b-11eb-946e-4dec76720c36.png)
