### PR TITLE
Updating the registered events

### DIFF
--- a/apps/forms-flow-ai/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/io/event/CamundaEventListener.java
+++ b/apps/forms-flow-ai/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/io/event/CamundaEventListener.java
@@ -103,7 +103,7 @@ public class CamundaEventListener implements ITaskEvent {
     }
 	
 	private String getDefaultRegisteredEvent() {
-        return "create,assignment,complete";
+        return "create,update,complete";
     }
 
     private ObjectMapper getObjectMapper() {


### PR DESCRIPTION
The assignment event also triggers an update event. So, update encompasses the assignment event which makes assignment a redundant event for web socket.