### PR TITLE
Fixed artifacts URL to prevent image pull error

### DIFF
--- a/apps/forms-flow-ai/forms-flow-bpm/Dockerfile
+++ b/apps/forms-flow-ai/forms-flow-bpm/Dockerfile
@@ -1,7 +1,7 @@
 # Modified by Yichun Zhao and Walter Moar
 
 # Maven build
-FROM docker-remote.artifacts.developer.gov.bc.ca/maven:3.6.1-jdk-11-slim AS MAVEN_TOOL_CHAIN
+FROM artifacts.developer.gov.bc.ca/docker-remote/maven:3.6.1-jdk-11-slim AS MAVEN_TOOL_CHAIN
 
 RUN apt-get update \
     && apt-get install -y git
@@ -28,7 +28,7 @@ RUN mvn -s /usr/share/maven/ref/settings-docker.xml package
 
 
 # Final custom slim java image (for apk command see jdk-11.0.3_7-alpine-slim)
-FROM docker-remote.artifacts.developer.gov.bc.ca/adoptopenjdk/openjdk11:jdk-11.0.3_7-alpine
+FROM artifacts.developer.gov.bc.ca/docker-remote/adoptopenjdk/openjdk11:jdk-11.0.3_7-alpine
 
 ENV JAVA_VERSION jdk-11.0.3+7
 ENV JAVA_HOME=/opt/java/openjdk \

--- a/apps/forms-flow-ai/forms-flow-web/Dockerfile
+++ b/apps/forms-flow-ai/forms-flow-web/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM docker-remote.artifacts.developer.gov.bc.ca/node:14.17.0-alpine as build-stage
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:14.17.0-alpine as build-stage
 
 # set working directory
 WORKDIR /app
@@ -28,7 +28,7 @@ COPY ./${CUSTOM_SVG_DIR}/ /app/${CUSTOM_SVG_DIR}/
 RUN npm install
 RUN npm run build
 
-FROM docker-remote.artifacts.developer.gov.bc.ca/nginx:1.17 as production-stage
+FROM artifacts.developer.gov.bc.ca/docker-remote/nginx:1.17 as production-stage
 RUN mkdir /app
 COPY --from=build-stage /app/build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
The URL for images has changed from _docker-remote.artifacts.developer.gov.bc.ca/..._ to _artifacts.developer.gov.bc.ca/docker-remote/..._. Fixed the Dockerfiles in formio to use the current URL and prevent image pull errors.

Details: https://stackoverflow.developer.gov.bc.ca/questions/790